### PR TITLE
Adds forced event processing for inter-execution feedback

### DIFF
--- a/python/app/redirect.py
+++ b/python/app/redirect.py
@@ -104,6 +104,7 @@ class StdoutRedirector(QtCore.QObject):
             msg = unicode.encode(msg, "utf-8")
 
         self.output.emit(msg)
+        QtCore.QCoreApplication.processEvents()
 
         if self._tee and self._handle:
             self._handle.write(msg)
@@ -156,6 +157,7 @@ class StderrRedirector(QtCore.QObject):
             msg = unicode.encode(msg, "utf-8")
 
         self.error.emit(msg)
+        QtCore.QCoreApplication.processEvents()
 
         if self._tee:
             self._handle.write(msg)


### PR DESCRIPTION
Forces a refresh during python execution - this will result in a continuous output during command execution. Previously, it would only do this upon idle, e.g. after a python command had completed execution. The implementation is naive so not sure this is right. In general, it seems the way the output widget gets updated will be slower and slower over time - if we wanted to fix the python console to handle larger volumes of logging, we would need to do a bigger pass.