### PR TITLE
General improvements to the editor

### DIFF
--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -228,7 +228,6 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
 
         :param event: key press event object.
         """
-
         if event.key() in [
             QtCore.Qt.Key_Enter,
             QtCore.Qt.Key_Return,
@@ -256,6 +255,11 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             super(PythonInputWidget, self).keyPressEvent(event)
 
     def remove_character_indentation(self):
+        """
+        Attempts to remove a single indentation block if there is no selection and the cursor is in the indentation
+        part of the line. It returns True if we unindented and False if we didn't.
+        :return: bool
+        """
         cur = self.textCursor()
         if not cur.hasSelection():
             user_cur_pos = cur.positionInBlock()
@@ -399,13 +403,23 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             self._operate_on_selected_lines(remove_comment_to_line)
 
     def _split_indentation(self, line):
+        """
+        Returns the line as a tuple broken up into indentation and the rest of the line.
+        :param line: str
+        :return: str
+        """
         first_char_pattern = re.compile(r"^([ \t]*)(.*)")
         m = first_char_pattern.match(line)
         return m.group(1), m.group(2)
 
-    def _get_indentation_length(self, line):
+    def _get_indentation_length(self, indentation_str):
+        """
+        Returns the length of the indentation_str but substitutes tabs for four spaces.
+        :param line: str
+        :return: str
+        """
         # convert any tabs to four spaces
-        return len(line.replace("\t", "    "))
+        return len(indentation_str.replace("\t", "    "))
 
     def indent(self):
         """

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -424,7 +424,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
     def _get_cursor_positions(self, cursor):
         """
         This method returns back the cursor's position, anchor, and the start and end.
-        Since the selection direction can be either way it can be  useful to know which
+        Since the selection direction can be either way it can be useful to know which
         out of the cursor and anchor positions are the earliest and furthest points, so the start
         and end is also provided.
         :param cursor:

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -691,7 +691,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             base_color = palette.base().color()
             highlight_color = palette.highlight().color()
 
-            self._cur_line_color = colorize(base_color, 2, highlight_color, 1,)
+            self._cur_line_color = colorize(base_color, 6, highlight_color, 1,)
 
         return self._cur_line_color
 

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -248,10 +248,6 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             super(PythonInputWidget, self).keyPressEvent(event)
 
     def _set_indentation(self, unindent=False):
-
-        # FIXME: bug if you unindent on thee first line, causes the app to hang
-        # FIXME: bug if you unindent without block selecting and you cursor is at the beginning of the line, it will
-        # shift on the previous line.
         def unindent_line(line):
             if line.startswith("    "):
                 return line[4:]
@@ -318,7 +314,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             # Move to the end of the line before checking, so that we can be sure the cursor cannot be on the
             # same line but before the start point.
             cur.movePosition(QtGui.QTextCursor.EndOfLine)
-            if cur.position() < start:
+            if cur.position() < start or beginning_of_line_pos == 0:
                 # We've moved a line above the start of the selection
                 if line != altered_line:
                     if unindent:
@@ -329,6 +325,11 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                         new_start_pos = (
                             new_start_pos
                             if new_start_pos >= beginning_of_line_pos
+                            else beginning_of_line_pos
+                        )
+                        new_end_pos = (
+                            new_end_pos
+                            if new_end_pos >= beginning_of_line_pos
                             else beginning_of_line_pos
                         )
                     else:
@@ -342,7 +343,6 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
         # Restore the selection, but alter it so that it is relative to the changes we made.
         if cur_pos > anchor:
             cur.setPosition(new_start_pos)
-            # if cur_pos != anchor:
             cur.setPosition(new_end_pos, QtGui.QTextCursor.KeepAnchor)
         else:
             cur.setPosition(new_end_pos)

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -398,7 +398,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             :return: `str`, the modified line.
             """
             # This regex should strip the first # before a character and the immediate space after if found.
-            altered_line = re.sub(r"^((?:[ \t]+)?)# ?", "\g<1>", line, 1)
+            altered_line = re.sub(r"^((?:[ \t]+)?)# ?", r"\g<1>", line, 1)
 
             return altered_line
 

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -438,11 +438,12 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
 
             # break the number of spaces down in to multiples of 4
             # so that we indent to whole levels of 4
-            r = n_spaces / 4
-            if type(r) is int or (type(r) is float and r.is_integer()):
+            r = n_spaces / 4.0
+            if r.is_integer():
                 n_spaces = n_spaces + 4
             else:
-                n_spaces = math.ceil(r) * 4
+                # math.floor returns an int in Python 3 and a float in Python 2 so ensure it's a int.
+                n_spaces = int(math.ceil(r) * 4)
 
             return (" " * n_spaces) + rest_of_line
 
@@ -458,11 +459,12 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             indentation, rest_of_line = self._split_indentation(line)
             n_spaces = self._get_indentation_length(indentation)
 
-            r = n_spaces / 4
-            if type(r) is int or (type(r) is float and r.is_integer()):
+            r = n_spaces / 4.0
+            if r.is_integer():
                 n_spaces = n_spaces - 4
             else:
-                n_spaces = math.floor(r) * 4
+                # math.floor returns an int in Python 3 and a float in Python 2 so ensure it's a int.
+                n_spaces = int(math.floor(r) * 4)
 
             return (" " * n_spaces) + rest_of_line
 

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -236,8 +236,8 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             self.insertPlainText("\n")
             event.accept()
         elif event.key() == QtCore.Qt.Key_Slash:
-            print("comment")
             self.block_comment_selection()
+            event.accept()
         elif event.key() == QtCore.Qt.Key_Backtab:
             # Unindent the code.
             self.unindent()

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -268,7 +268,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             # Now separate out the indentation from the rest of the line and figure out how many spaces it is.
             indentation, rest_of_line = self._split_indentation(line)
 
-            # Te current user cursor position is within the indentation.
+            # The current user cursor position is within the indentation.
             if user_cur_pos <= len(indentation) and len(indentation) != 0:
                 self.unindent()
                 return True

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -278,6 +278,12 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
         indentation, rest_of_line = self._split_indentation(line)
         n_spaces = self._get_indentation_length(indentation)
 
+        # We should check the current position in the line, if it sits somewhere in the indentation then match that.
+        user_cur = self.textCursor()
+        user_cur_pos = user_cur.positionInBlock()
+        if not user_cur.hasSelection() and user_cur_pos and user_cur_pos < n_spaces:
+            n_spaces = user_cur_pos
+
         # Add a new line plus the number of spaces in the previous line.
         new_line = "\n" + (" " * n_spaces)
 

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -248,6 +248,10 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             super(PythonInputWidget, self).keyPressEvent(event)
 
     def _set_indentation(self, unindent=False):
+
+        # FIXME: bug if you unindent on thee first line, causes the app to hang
+        # FIXME: bug if you unindent without block selecting and you cursor is at the beginning of the line, it will
+        # shift on the previous line.
         def unindent_line(line):
             if line.startswith("    "):
                 return line[4:]

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -439,7 +439,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             # break the number of spaces down in to multiples of 4
             # so that we indent to whole levels of 4
             r = n_spaces / 4
-            if r.is_integer():
+            if type(r) is int or (type(r) is float and r.is_integer()):
                 n_spaces = n_spaces + 4
             else:
                 n_spaces = math.ceil(r) * 4
@@ -459,7 +459,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             n_spaces = self._get_indentation_length(indentation)
 
             r = n_spaces / 4
-            if r.is_integer():
+            if type(r) is int or (type(r) is float and r.is_integer()):
                 n_spaces = n_spaces - 4
             else:
                 n_spaces = math.floor(r) * 4

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -320,6 +320,11 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
         cur.endEditBlock()
 
     def block_comment_selection(self):
+        """
+        Either adds or removes comments from the selected line. If one line in the selection doesn't contain a comment
+         then it will add comments to all lines, otherwise it will remove comments from all lines.
+        :return: None
+        """
 
         # Before attempting to alter the line, we should loop over the selected lines
         # and check if any don't have a # at the start. If we find a line that doesn't then we

--- a/python/app/syntax_highlighter.py
+++ b/python/app/syntax_highlighter.py
@@ -192,7 +192,7 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
                 style="",
             ),
             "comment": _format(
-                colorize(palette.windowText().color(), 1, palette.base().color(), 2,),
+                colorize(palette.windowText().color(), 1, palette.base().color(), 1,),
                 style="italic",
             ),
             "self": _format(

--- a/tests/test_standalone_app.py
+++ b/tests/test_standalone_app.py
@@ -185,7 +185,9 @@ def test_execute_script(
             "    a = 1\n"
             "        b = 2\n"
             "    c = 3",
+            # action
             "indent",
+            # cursor selection start and end position (None selects all)
             None,
         ),
         (
@@ -203,7 +205,7 @@ def test_execute_script(
             "    e = 5",
             # action
             "unindent",
-            # cursor selection start and end position
+            # cursor selection start and end position (None selects all)
             None,
         ),
         # test adding a comment
@@ -220,7 +222,7 @@ def test_execute_script(
             "#         d = 4",
             # action
             "comment",
-            # cursor selection start and end position
+            # cursor selection start and end position (None selects all)
             None,
         ),
         # test removing a comment
@@ -233,7 +235,7 @@ def test_execute_script(
             "    b = 2",
             # action
             "comment",
-            # cursor selection start and end position
+            # cursor selection start and end position (None selects all)
             None,
         ),
         # test comments being added at the correct level of indentation
@@ -246,7 +248,7 @@ def test_execute_script(
             "    # b = 2",
             # action
             "comment",
-            # cursor selection start and end position
+            # cursor selection start and end position (None selects all)
             None
         ),
         # test removing character when cursor in indentation

--- a/tests/test_standalone_app.py
+++ b/tests/test_standalone_app.py
@@ -176,11 +176,12 @@ def test_execute_script(
 @pytest.mark.parametrize(
     "script, altered_script, operation, selection_range",
     [
+        # test adding an indent. Should round up to the nearest for spaces.
         (
             # source
             "a = 1\n"
             "    b = 2\n"
-            "c = 3",
+            " c = 3",
             # result
             "    a = 1\n"
             "        b = 2\n"
@@ -190,6 +191,7 @@ def test_execute_script(
             # cursor selection start and end position (None selects all)
             None,
         ),
+        # test unindenting. Should round up to the nearest for spaces.
         (
             # source
             "a = 1\n"

--- a/tests/test_standalone_app.py
+++ b/tests/test_standalone_app.py
@@ -208,6 +208,10 @@ def test_execute_script(
         ("    a = 1", "    a = 1\n    ", "new_line", (9, 9)),
         # test adding a to a new line to a selection
         ("    a = 1", "    a\n    ", "new_line", (5, 9)),
+        # test adding a new line after a colon, it should auto indent by 4
+        ("    def test(): ", "    def test(): \n        ", "new_line", (16, 16)),
+        # test adding a new line with the selection before the colon, it should indent to the same level.
+        ("    def test(): ", "    def test(\n    ): ", "new_line", (13, 13)),
     ],
 )
 def test_block_text_operations(

--- a/tests/test_standalone_app.py
+++ b/tests/test_standalone_app.py
@@ -172,50 +172,172 @@ def test_execute_script(
         assert actual_output == expected_output
 
 
+# fmt: off
 @pytest.mark.parametrize(
     "script, altered_script, operation, selection_range",
     [
         (
-            "a = 1\n    b = 2\n c = 3",
-            "    a = 1\n        b = 2\n    c = 3",
+            # source
+            "a = 1\n"
+            "    b = 2\n"
+            "c = 3",
+            # result
+            "    a = 1\n"
+            "        b = 2\n"
+            "    c = 3",
             "indent",
             None,
         ),
         (
-            "a = 1\n    b = 2\n c = 3\n        d = 4\n     e = 5",
-            "a = 1\nb = 2\nc = 3\n    d = 4\n    e = 5",
+            # source
+            "a = 1\n"
+            "    b = 2\n"
+            " c = 3\n"
+            "        d = 4\n"
+            "     e = 5",
+            # result
+            "a = 1\n"
+            "b = 2\n"
+            "c = 3\n"
+            "    d = 4\n"
+            "    e = 5",
+            # action
             "unindent",
+            # cursor selection start and end position
             None,
         ),
         # test adding a comment
         (
-            "a = 1\n    # b = 2\n c = 3\n        d = 4",
-            "# a = 1\n#     # b = 2\n#  c = 3\n#         d = 4",
+            # source
+            "a = 1\n"
+            "    # b = 2\n"
+            " c = 3\n"
+            "        d = 4",
+            # result
+            "# a = 1\n"
+            "#     # b = 2\n"
+            "#  c = 3\n"
+            "#         d = 4",
+            # action
             "comment",
+            # cursor selection start and end position
             None,
         ),
         # test removing a comment
-        ("# a = 1\n    # b = 2", "a = 1\n    b = 2", "comment", None),
+        (
+            # Source
+            "# a = 1\n"
+            "    # b = 2",
+            # result
+            "a = 1\n"
+            "    b = 2",
+            # action
+            "comment",
+            # cursor selection start and end position
+            None,
+        ),
         # test comments being added at the correct level of indentation
-        ("    a = 1\n    b = 2", "    # a = 1\n    # b = 2", "comment", None),
+        (
+            # source
+            "    a = 1\n"
+            "    b = 2",
+            # result
+            "    # a = 1\n"
+            "    # b = 2",
+            # action
+            "comment",
+            # cursor selection start and end position
+            None
+        ),
         # test removing character when cursor in indentation
-        ("    a = 1", "a = 1", "delete", (4, 4)),
+        (
+            # source
+            "    a = 1",
+            # result
+            "a = 1",
+            # action
+            "delete",
+            # cursor selection start and end position
+            (4, 4)
+        ),
         # test removing character when cursor in indentation
-        ("     a = 1", "    a = 1", "delete", (4, 4)),
+        (
+            # source
+            "     a = 1",
+            # result
+            "    a = 1",
+            # action
+            "delete",
+            # cursor selection start and end position
+            (4, 4)),
         # test removing character when cursor not in indentation
-        ("    a = 1", "    a = ", "delete", (9, 9)),
+        (
+            # source
+            "    a = 1",
+            # result
+            "    a = ",
+            # action
+            "delete",
+            # cursor selection start and end position
+            (9, 9)),
         # test adding a new line
-        ("    a = 1", "    a = 1\n    ", "new_line", (9, 9)),
+        (
+            # source
+            "    a = 1",
+            # result
+            "    a = 1\n"
+            "    ",
+            # action
+            "new_line",
+            # cursor selection start and end position
+            (9, 9)),
         # test adding a to a new line to a selection
-        ("    a = 1", "    a\n    ", "new_line", (5, 9)),
+        (
+            # source
+            "    a = 1",
+            # result
+            "    a\n"
+            "    ",
+            # action
+            "new_line",
+            # cursor selection start and end position
+            (5, 9)),
         # test adding a new line after a colon, it should auto indent by 4
-        ("    def test(): ", "    def test(): \n        ", "new_line", (16, 16)),
+        (
+            # source
+            "    def test(): ",
+            # result
+            "    def test(): \n"
+            "        ",
+            # action
+            "new_line",
+            # cursor selection start and end position
+            (16, 16)),
         # test adding a new line after a colon with an inline comment, it should auto indent by 4
-        ("def test(): # asd#.", "def test(): # asd#.\n    ", "new_line", (19, 19)),
+        (
+            # source
+            "def test(): # asd#.",
+            # result
+            "def test(): # asd#.\n"
+            "    ",
+            # action
+            "new_line",
+            # cursor selection start and end position
+            (19, 19)),
         # test adding a new line with the selection before the colon, it should indent to the same level.
-        ("    def test(): ", "    def test(\n    ): ", "new_line", (13, 13)),
+        (
+            # source
+            "    def test(): ",
+            # result
+            "    def test(\n"
+            "    ): ",
+            # action
+            "new_line",
+            # cursor selection start and end position
+            (13, 13)),
     ],
 )
+# fmt: on
 def test_block_text_operations(
     console_widget, script, altered_script, operation, selection_range
 ):

--- a/tests/test_standalone_app.py
+++ b/tests/test_standalone_app.py
@@ -210,6 +210,8 @@ def test_execute_script(
         ("    a = 1", "    a\n    ", "new_line", (5, 9)),
         # test adding a new line after a colon, it should auto indent by 4
         ("    def test(): ", "    def test(): \n        ", "new_line", (16, 16)),
+        # test adding a new line after a colon with an inline comment, it should auto indent by 4
+        ("def test(): # asd#.", "def test(): # asd#.\n    ", "new_line", (19, 19)),
         # test adding a new line with the selection before the colon, it should indent to the same level.
         ("    def test(): ", "    def test(\n    ): ", "new_line", (13, 13)),
     ],


### PR DESCRIPTION
Now supports block indent and unindent
Now supports block commenting and uncommenting
Now when you press return for a new line, it will start indented at the previous level
Now when you press backspace to remove the indentation it removes the indentation in blocks of multiples of 4 spaces.
Now when you press new line after a `:` character it will auto indent the next line by and extra 4 characters.
Tests have been written for these changes, and they reproduced by use simulating the key presses. They don't cover every detail that was implemented but cover the majority.

Saving a script now defaults to a `.py` extension, (no tests are written for this.)

Indenting and unindenting alters the text to the nearest indent in multiples of four spaces.
Example:
```
  a = 1
```
would become when indented
```
    a = 1
```
but
```
    a = 1
```
would become 
```
        a = 1
```

When indenting or unindenting lines with tabs, it should convert them to spaces.

I've also tweaked the editor colours, making the selected line highlighting less bright, and increasing the comment brightness a bit.
Was:
<img width="171" alt="Shotgun__Shotgun_Python_Console" src="https://user-images.githubusercontent.com/3777228/76632235-cb355500-653a-11ea-8be2-334e52f283ff.png">
Now:
<img width="196" alt="Shotgun__Shotgun_Python_Console" src="https://user-images.githubusercontent.com/3777228/76632154-a7720f00-653a-11ea-9d5c-81d539e36577.png">
