### PR TITLE
SG-17518 Only comments out line if the cmd/ctrl key and the / key is pressed.

### DIFF
--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -280,7 +280,10 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                 event.accept()
             else:
                 super(PythonInputWidget, self).keyPressEvent(event)
-        elif event.key() == QtCore.Qt.Key_Slash:
+        elif (
+            event.key() == QtCore.Qt.Key_Slash
+            and event.modifiers() == QtCore.Qt.ControlModifier
+        ):
             self.block_comment_selection()
             event.accept()
         elif event.key() == QtCore.Qt.Key_Backtab:

--- a/tests/test_standalone_app.py
+++ b/tests/test_standalone_app.py
@@ -374,19 +374,21 @@ def test_block_text_operations(
     input_widget.setTextCursor(cur)
     QtCore.QCoreApplication.processEvents()
 
+    modifier = QtCore.Qt.NoModifier
     if operation == "indent":
         key = QtCore.Qt.Key_Tab
     elif operation == "unindent":
         key = QtCore.Qt.Key_Backtab
     elif operation == "comment":
         key = QtCore.Qt.Key_Slash
+        modifier = QtCore.Qt.ControlModifier
     elif operation == "delete":
         key = QtCore.Qt.Key_Backspace
     elif operation == "new_line":
         key = QtCore.Qt.Key_Return
 
     # Now simulate the key press for the correct operation.
-    event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, QtCore.Qt.NoModifier)
+    event = QtGui.QKeyEvent(QtCore.QEvent.KeyPress, key, modifier)
     QtCore.QCoreApplication.postEvent(input_widget, event)
     QtCore.QCoreApplication.processEvents()
 


### PR DESCRIPTION
Fixes a bug where if you pressed the `/` key on its own it would comment out the line leaving you unable to actually enter that character. This fix makes sure it only comments out the line when combined with the `cmd`/`ctrl` key.