### PR TITLE
SG-18538 Fix for RV crash when console executing code produces error.

### DIFF
--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -205,8 +205,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                 python_code = compile(python_script, "python input", "exec")
             except SyntaxError:
                 # oops, syntax error. write to our stderr
-                with self._stderr_redirect as stderr:
-                    stderr.write(self._format_exc())
+                self._stderr_redirect.write(self._format_exc())
                 return
 
         # exec the python code, redirecting any stdout to the ouptut signal.
@@ -231,8 +230,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                         results = eval(python_code, self._locals, self._locals)
                     except Exception:
                         # oops, error encountered. write/redirect to the error signal
-                        with self._stderr_redirect as stderr:
-                            stderr.write(self._format_exc())
+                        self._stderr_redirect.write(self._format_exc())
                     else:
                         self.results.emit(str(results))
 
@@ -248,8 +246,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                         exec(python_code, self._locals, self._locals)
                     except Exception:
                         # oops, error encountered. write/redirect to the error signal
-                        with self._stderr_redirect as stderr:
-                            stderr.write(self._format_exc())
+                        self._stderr_redirect.write(self._format_exc())
 
     def highlight_current_line(self):
         """Highlight the current line of the input widget."""

--- a/python/app/output_widget.py
+++ b/python/app/output_widget.py
@@ -155,7 +155,7 @@ class OutputStreamWidget(QtGui.QTextBrowser):
         # if shotgun/toolkit is available, log the error message to the current
         # engine.
         if sgtk:
-            sgtk.platform.current_engine().log_error(text)
+            sgtk.platform.current_engine().logger.error(text)
 
         if six:
             # if six can be imported sanitize the string.


### PR DESCRIPTION
This fixes an issue when an error is raised during execution of the code in the console, it could create feedback loop of calls to stderr.

This resulted in the whole of RV crashing out immediately if your code had an error.