### PR TITLE
SG-18896 Hard code a colour scheme so we can rely on the colour in any setting

### DIFF
--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -694,7 +694,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
             base_color = palette.base().color()
             highlight_color = palette.highlight().color()
 
-            self._cur_line_color = colorize(base_color, 6, highlight_color, 1,)
+            self._cur_line_color = QtGui.QColor(50, 50, 50)
 
         return self._cur_line_color
 
@@ -706,11 +706,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
         """Get a line number base color."""
 
         if not hasattr(self, "_line_num_base_color"):
-            palette = self.palette()
-            base_color = palette.base().color()
-            window_color = palette.window().color()
-
-            self._line_num_base_color = colorize(base_color, 1, window_color, 1,)
+            self._line_num_base_color = QtGui.QColor(49, 51, 53)
 
         return self._line_num_base_color
 
@@ -718,12 +714,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
         """Get a line number color."""
 
         if not hasattr(self, "_line_num_color"):
-
-            palette = self.palette()
-            base_color = palette.base().color()
-            highlight_color = palette.highlight().color()
-
-            self._line_num_color = colorize(base_color, 1, highlight_color, 2,)
+            self._line_num_color = QtGui.QColor(96, 99, 102)
 
         return self._line_num_color
 

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -205,8 +205,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                 python_code = compile(python_script, "python input", "exec")
             except SyntaxError:
                 # oops, syntax error. write to our stderr
-                with self._stderr_redirect as stderr:
-                    stderr.write(self._format_exc())
+                self._stderr_redirect.write(self._format_exc())
                 return
 
         # exec the python code, redirecting any stdout to the ouptut signal.
@@ -231,8 +230,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                         results = eval(python_code, self._locals, self._locals)
                     except Exception:
                         # oops, error encountered. write/redirect to the error signal
-                        with self._stderr_redirect as stderr:
-                            stderr.write(self._format_exc())
+                        self._stderr_redirect.write(self._format_exc())
                     else:
                         self.results.emit(str(results))
 
@@ -248,8 +246,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
                         exec(python_code, self._locals, self._locals)
                     except Exception:
                         # oops, error encountered. write/redirect to the error signal
-                        with self._stderr_redirect as stderr:
-                            stderr.write(self._format_exc())
+                        self._stderr_redirect.write(self._format_exc())
 
     def highlight_current_line(self):
         """Highlight the current line of the input widget."""

--- a/python/app/output_widget.py
+++ b/python/app/output_widget.py
@@ -155,7 +155,7 @@ class OutputStreamWidget(QtGui.QTextBrowser):
         # if shotgun/toolkit is available, log the error message to the current
         # engine.
         if sgtk:
-            sgtk.platform.current_engine().log_error(text)
+            sgtk.platform.current_engine().logger.error(text)
 
         if six:
             # if six can be imported sanitize the string.

--- a/python/app/syntax_highlighter.py
+++ b/python/app/syntax_highlighter.py
@@ -129,6 +129,14 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
         # All other rules
         rules += [
+            # Numeric literals
+            (r"\b[+-]?[0-9]+[lL]?\b", 0, self._style("numbers")),
+            (r"\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\b", 0, self._style("numbers")),
+            (
+                r"\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b",
+                0,
+                self._style("numbers"),
+            ),
             # 'self'
             (r"\bself\b", 0, self._style("self")),
             # Double-quoted string, possibly containing escape sequences
@@ -141,14 +149,6 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
             (r"\bclass\b\s*(\w+)", 1, self._style("defclass")),
             # From '#' until a newline
             (r"#[^\n]*", 0, self._style("comment")),
-            # Numeric literals
-            (r"\b[+-]?[0-9]+[lL]?\b", 0, self._style("numbers")),
-            (r"\b[+-]?0[xX][0-9A-Fa-f]+[lL]?\b", 0, self._style("numbers")),
-            (
-                r"\b[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?\b",
-                0,
-                self._style("numbers"),
-            ),
         ]
 
         # Build a QtCore.QRegExp for each pattern
@@ -156,55 +156,45 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
     def _style(self, style_type):
 
-        palette = self._palette
-
         styles = {
             "keyword": _format(
-                colorize(palette.windowText().color(), 3, QtGui.QColor(0, 0, 255), 1,),
+                QtGui.QColor(204, 120, 50),
                 style="",
             ),
             "builtin": _format(
-                colorize(palette.windowText().color(), 3, QtGui.QColor(0, 255, 0), 1,),
+                QtGui.QColor(136, 136, 198),
                 style="",
             ),
             "operator": _format(
-                colorize(
-                    palette.windowText().color(), 4, palette.highlight().color(), 2,
-                ),
+                QtGui.QColor(169, 183, 198),
                 style="",
             ),
             "brace": _format(
-                colorize(palette.windowText().color(), 2, palette.base().color(), 1,),
-                style="bold",
+                QtGui.QColor(169, 183, 198),
+                style="",
             ),
             "defclass": _format(
-                colorize(palette.windowText().color(), 3, QtGui.QColor(255, 0, 0), 1,),
+                QtGui.QColor(255, 198, 109),
                 style="bold",
             ),
             "string": _format(
-                colorize(
-                    palette.windowText().color(), 2, palette.highlight().color(), 1,
-                ),
+                QtGui.QColor(106, 135, 89),
                 style="bold",
             ),
             "string2": _format(
-                colorize(palette.windowText().color(), 1, palette.base().color(), 1,),
+                QtGui.QColor(98, 151, 85),
                 style="",
             ),
             "comment": _format(
-                colorize(palette.windowText().color(), 1, palette.base().color(), 1,),
+                QtGui.QColor(128, 128, 128),
                 style="italic",
             ),
             "self": _format(
-                colorize(
-                    palette.windowText().color(), 1, QtGui.QColor(127, 127, 127), 1,
-                ),
+                QtGui.QColor(148, 85, 141),
                 style="",
             ),
             "numbers": _format(
-                colorize(
-                    palette.windowText().color(), 3, QtGui.QColor(127, 127, 127), 1,
-                ),
+                QtGui.QColor(104, 151, 187),
                 style="",
             ),
         }

--- a/python/app/syntax_highlighter.py
+++ b/python/app/syntax_highlighter.py
@@ -157,46 +157,16 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
     def _style(self, style_type):
 
         styles = {
-            "keyword": _format(
-                QtGui.QColor(204, 120, 50),
-                style="",
-            ),
-            "builtin": _format(
-                QtGui.QColor(136, 136, 198),
-                style="",
-            ),
-            "operator": _format(
-                QtGui.QColor(169, 183, 198),
-                style="",
-            ),
-            "brace": _format(
-                QtGui.QColor(169, 183, 198),
-                style="",
-            ),
-            "defclass": _format(
-                QtGui.QColor(255, 198, 109),
-                style="bold",
-            ),
-            "string": _format(
-                QtGui.QColor(106, 135, 89),
-                style="bold",
-            ),
-            "string2": _format(
-                QtGui.QColor(98, 151, 85),
-                style="",
-            ),
-            "comment": _format(
-                QtGui.QColor(128, 128, 128),
-                style="italic",
-            ),
-            "self": _format(
-                QtGui.QColor(148, 85, 141),
-                style="",
-            ),
-            "numbers": _format(
-                QtGui.QColor(104, 151, 187),
-                style="",
-            ),
+            "keyword": _format(QtGui.QColor(204, 120, 50), style="",),
+            "builtin": _format(QtGui.QColor(136, 136, 198), style="",),
+            "operator": _format(QtGui.QColor(169, 183, 198), style="",),
+            "brace": _format(QtGui.QColor(169, 183, 198), style="",),
+            "defclass": _format(QtGui.QColor(255, 198, 109), style="bold",),
+            "string": _format(QtGui.QColor(106, 135, 89), style="bold",),
+            "string2": _format(QtGui.QColor(98, 151, 85), style="",),
+            "comment": _format(QtGui.QColor(128, 128, 128), style="italic",),
+            "self": _format(QtGui.QColor(148, 85, 141), style="",),
+            "numbers": _format(QtGui.QColor(104, 151, 187), style="",),
         }
 
         return styles[style_type]

--- a/style.qss
+++ b/style.qss
@@ -18,6 +18,8 @@ QTextEdit {
 
 QPlainTextEdit {
     font-family: "Courier";
+    background-color: rgb(43, 43, 43);
+    color: rgb(169, 183, 198);
 }
 
 _LineNumberArea {

--- a/style.qss
+++ b/style.qss
@@ -113,6 +113,7 @@ QScrollArea {
 
 QTextBrowser {
     border: none;
+    background-color: rgb(43, 43, 43);
 }
 
 QPlainTextEdit {


### PR DESCRIPTION
This work was meant to make the python console more readable in RV. We used to mix certain colours in with the pallete's base colours but this did not work well in RV. Hard-coding the scheme makes it consistent across all DCCs.

The order of the highlighting rules was also making quoted numerals like `"123"` be treated as numbers instead of text. Reordering the rules fixes this problem

### Old Look
![old_color_scheme](https://user-images.githubusercontent.com/4356899/93798701-f340f780-fbf2-11ea-9758-c161960f39ff.jpg)

### New Look
![new_color_scheme](https://user-images.githubusercontent.com/4356899/93798707-f6d47e80-fbf2-11ea-92cd-cc0a4d357dca.jpg)
