### PR TITLE
Fixed text string casting value not being stored.

### DIFF
--- a/python/app/output_widget.py
+++ b/python/app/output_widget.py
@@ -131,10 +131,10 @@ class OutputStreamWidget(QtGui.QTextBrowser):
 
         if six:
             # if six can be imported sanitize the string.
-            # This may lead to unicode errors if not imported in python 2
+            # This may lead to unicode errors if not imported in Python 2
             text = six.ensure_str(text)
         else:
-            str(text)
+            text = str(text)
 
         with self._write_lock:
             text = self._to_html(text)


### PR DESCRIPTION
Fixes a mistake that crept in during Python 3 work. I'm not sure we've actually seen this cause an issue however as six is most likely always present, but I just happened to spot it.