### PR TITLE
Fixes error logging when no engine is available.

### DIFF
--- a/python/app/output_widget.py
+++ b/python/app/output_widget.py
@@ -154,7 +154,7 @@ class OutputStreamWidget(QtGui.QTextBrowser):
 
         # if shotgun/toolkit is available, log the error message to the current
         # engine.
-        if sgtk:
+        if sgtk and sgtk.platform.current_engine():
             sgtk.platform.current_engine().logger.error(text)
 
         if six:
@@ -162,7 +162,7 @@ class OutputStreamWidget(QtGui.QTextBrowser):
             # This may lead to unicode errors if not imported in python 2
             text = six.ensure_str(text)
         else:
-            str(text)
+            text = str(text)
 
         # write the error
         with self._write_lock:


### PR DESCRIPTION
Before this it would cause errors to not even be displayed in the console since it expected an engine to be present.
Also fixes a case of a cast not being stored to a variable.
Thanks to the Flame team for this fix!