### PR TITLE
SHOT-3658: Allow engine to run tk-multi-pythonconsole at start up

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,6 +72,7 @@ class PythonConsoleApp(sgtk.platform.Application):
             "Python Console",
             self,
             app_payload.shotgun_console.ShotgunPythonConsoleWidget,
+            engine=self.engine,
         )
         self._current_dialog = widget
         return widget
@@ -93,6 +94,7 @@ class PythonConsoleApp(sgtk.platform.Application):
                 "Shotgun Python Console",
                 self,
                 app_payload.shotgun_console.ShotgunPythonConsoleWidget,
+                engine=self.engine,
             )
         except AttributeError as e:
             # just to gracefully handle older engines and older cores

--- a/python/app/shotgun_console.py
+++ b/python/app/shotgun_console.py
@@ -33,7 +33,7 @@ class ShotgunPythonConsoleWidget(PythonConsoleWidget):
 
     """
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, engine=None):
         """
         Initialize the console widget.
 
@@ -42,7 +42,15 @@ class ShotgunPythonConsoleWidget(PythonConsoleWidget):
 
         super(ShotgunPythonConsoleWidget, self).__init__(parent)
 
-        self._engine = None
+        # Use the engine passed in or default to the current engine
+        self._engine = engine or current_engine()
+
+        # if not running in an engine, then we're hosed
+        if not self._engine:
+            raise TankError(
+                "Unable to initialize ShotgunPythonConsole. No engine running"
+            )
+
         self._settings_manager = settings.UserSettings(sgtk.platform.current_bundle())
 
         # add a welcome message to the output widget
@@ -93,26 +101,6 @@ class ShotgunPythonConsoleWidget(PythonConsoleWidget):
         app = QtGui.QApplication.instance()
         app.aboutToQuit.connect(self._save_settings)
 
-    @property
-    def engine(self):
-        """
-        Property for the engine associated with the Shotgun Console.
-        """
-
-        if not self._engine:
-            # Default to the currently running engine. In some cases the current engine
-            # is not set before this widget requires it (e.g. if an engine runs
-            # tk-multi-pythonconsole at start up), so fallback to the app's engine.
-            self._engine = current_engine() or sgtk.platform.current_bundle().engine
-
-            # If not running in an engine, then we're hosed.
-            if not self._engine:
-                raise TankError(
-                    "Unable to initialize ShotgunPythonConsole. No engine running"
-                )
-
-        return self._engine
-
     def closeEvent(self, event):
         """
         Handles saving settings for the console before it is closed.
@@ -131,10 +119,10 @@ class ShotgunPythonConsoleWidget(PythonConsoleWidget):
         """
 
         return {
-            "tk": self.engine.tank,
-            "shotgun": self.engine.shotgun,
-            "context": self.engine.context,
-            "engine": self.engine,
+            "tk": self._engine.tank,
+            "shotgun": self._engine.shotgun,
+            "context": self._engine.context,
+            "engine": self._engine,
         }
 
     def _save_settings(self):


### PR DESCRIPTION
Found this issue when setting tk-vred engine to run tk-multi-pythonconsole at start up from the config. The `curerent_engine()` returns None is this scenario because the engine creates this app during it's initialization process and has not yet set the current engine. To resolve this, we attempt to get the engine from the app itself.