### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-multi-pythonconsole?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=48&branchName=master)
 [![codecov](https://codecov.io/gh/shotgunsoftware/tk-multi-pythonconsole/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-multi-pythonconsole)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/python/app/console.py
+++ b/python/app/console.py
@@ -244,7 +244,8 @@ class PythonConsoleWidget(QtGui.QWidget):
         with io.open(path, "r", encoding="utf-8") as fh:
             python_script = "".join(fh.readlines())
             index = self.tabs.add_tab(
-                name=os.path.split(path)[-1], contents=python_script,
+                name=os.path.split(path)[-1],
+                contents=python_script,
             )
             widget = self.tabs.widget(index)
             widget.input_widget.setPlainText(python_script)
@@ -532,7 +533,10 @@ class _PythonInputInfoWidget(QtGui.QWidget):
         layout.addWidget(self._column_lbl)
 
         self._text_grey = colorize(
-            self.palette().window().color(), 1, self.palette().windowText().color(), 1,
+            self.palette().window().color(),
+            1,
+            self.palette().windowText().color(),
+            1,
         ).name()
 
     def set_current_column(self, col):
@@ -542,5 +546,9 @@ class _PythonInputInfoWidget(QtGui.QWidget):
         :param int col: The column number to display.
         """
         self._column_lbl.setText(
-            "<font color='%s'>col: %s</font>" % (self._text_grey, str(col),)
+            "<font color='%s'>col: %s</font>"
+            % (
+                self._text_grey,
+                str(col),
+            )
         )

--- a/python/app/input_widget.py
+++ b/python/app/input_widget.py
@@ -178,7 +178,7 @@ class PythonInputWidget(QtGui.QPlainTextEdit):
         # If the selection obtained from an editor spans a line break, the
         # text will contain a Unicode U+2029 paragraph separator character
         # instead of a newline \n character.
-        python_script = python_script.replace(u"\u2029", "\n")
+        python_script = python_script.replace("\u2029", "\n")
         python_script = str(python_script).strip()
 
         if not python_script:

--- a/python/app/output_widget.py
+++ b/python/app/output_widget.py
@@ -183,7 +183,10 @@ class OutputStreamWidget(QtGui.QTextBrowser):
         if not hasattr(self, "_input_color"):
 
             self._input_color = colorize(
-                self.palette().base().color(), 1, QtGui.QColor(127, 127, 127), 2,
+                self.palette().base().color(),
+                1,
+                QtGui.QColor(127, 127, 127),
+                2,
             )
 
         return self._input_color
@@ -193,7 +196,12 @@ class OutputStreamWidget(QtGui.QTextBrowser):
 
         if not hasattr(self, "_err_color"):
 
-            self._err_color = colorize(self.textColor(), 1, QtGui.QColor(255, 0, 0), 3,)
+            self._err_color = colorize(
+                self.textColor(),
+                1,
+                QtGui.QColor(255, 0, 0),
+                3,
+            )
 
         return self._err_color
 

--- a/python/app/syntax_highlighter.py
+++ b/python/app/syntax_highlighter.py
@@ -32,8 +32,7 @@ from .util import colorize
 
 
 def _format(color, style=""):
-    """Return a QtGui.QTextCharFormat with the given attributes.
-    """
+    """Return a QtGui.QTextCharFormat with the given attributes."""
 
     _format = QtGui.QTextCharFormat()
     _format.setForeground(color)
@@ -157,23 +156,52 @@ class PythonSyntaxHighlighter(QtGui.QSyntaxHighlighter):
     def _style(self, style_type):
 
         styles = {
-            "keyword": _format(QtGui.QColor(204, 120, 50), style="",),
-            "builtin": _format(QtGui.QColor(136, 136, 198), style="",),
-            "operator": _format(QtGui.QColor(169, 183, 198), style="",),
-            "brace": _format(QtGui.QColor(169, 183, 198), style="",),
-            "defclass": _format(QtGui.QColor(255, 198, 109), style="bold",),
-            "string": _format(QtGui.QColor(106, 135, 89), style="bold",),
-            "string2": _format(QtGui.QColor(98, 151, 85), style="",),
-            "comment": _format(QtGui.QColor(128, 128, 128), style="italic",),
-            "self": _format(QtGui.QColor(148, 85, 141), style="",),
-            "numbers": _format(QtGui.QColor(104, 151, 187), style="",),
+            "keyword": _format(
+                QtGui.QColor(204, 120, 50),
+                style="",
+            ),
+            "builtin": _format(
+                QtGui.QColor(136, 136, 198),
+                style="",
+            ),
+            "operator": _format(
+                QtGui.QColor(169, 183, 198),
+                style="",
+            ),
+            "brace": _format(
+                QtGui.QColor(169, 183, 198),
+                style="",
+            ),
+            "defclass": _format(
+                QtGui.QColor(255, 198, 109),
+                style="bold",
+            ),
+            "string": _format(
+                QtGui.QColor(106, 135, 89),
+                style="bold",
+            ),
+            "string2": _format(
+                QtGui.QColor(98, 151, 85),
+                style="",
+            ),
+            "comment": _format(
+                QtGui.QColor(128, 128, 128),
+                style="italic",
+            ),
+            "self": _format(
+                QtGui.QColor(148, 85, 141),
+                style="",
+            ),
+            "numbers": _format(
+                QtGui.QColor(104, 151, 187),
+                style="",
+            ),
         }
 
         return styles[style_type]
 
     def highlightBlock(self, text):
-        """Apply syntax highlighting to the given block of text.
-        """
+        """Apply syntax highlighting to the given block of text."""
         # Do other syntax formatting
         for expression, nth, format in self.rules:
             index = expression.indexIn(text, 0)


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site