### PR TITLE
SG-31576: Qt6/PySide6 support

### DIFF
--- a/python/app/qt_importer.py
+++ b/python/app/qt_importer.py
@@ -17,16 +17,33 @@
 try:
     from sgtk.platform.qt import QtCore, QtGui
 except ImportError:
+    __PySide_QtGui = None
+    __PySide_QtWidgets = None
     try:
-        # Try to import from PySide2 and keep the QtGui interface
-        # consistent with PySide (Qt 4).
-        # We don't try to cover all cases, only the QtGui module as we
-        # are using components from that which are different between Qt 5 and 4.
-        # Approach is taken from the `tk-core` `pyside2_patcher.py` module.
+        # Try to import from PySide2
         from PySide2 import QtCore
-        import PySide2.QtGui as __PySide2_QtGui
-        import PySide2.QtWidgets as __PySide2_QtWidgets
+        import PySide2.QtGui as __PySide_QtGui
+        import PySide2.QtWidgets as __PySide_QtWidgets
+    except ImportError:
+        pass
 
+    if __PySide_QtGui is None or __PySide_QtWidgets is None:
+        # Try PySide6
+        try:
+            from PySide6 import QtCore
+            import PySide6.QtGui as __PySide_QtGui
+            import PySide6.QtWidgets as __PySide_QtWidgets
+        except ImportError:
+            pass
+
+    if __PySide_QtGui is None or __PySide_QtWidgets is None:
+        # Try PySide
+        from PySide import QtCore, QtGui
+    else:
+        # Patch PySide2/PySide6 to keep the QtGui interface consistent with PySide (Qt 4).
+        # We don't try to cover all cases, only the QtGui module as we are using components
+        # from that which are different between Qt 5 and 4. Approach is taken from the
+        # `tk-core` `pyside2_patcher.py` module.
         def _move_attributes(dst, src, names):
             """
             Moves a list of attributes from one package to another.
@@ -37,11 +54,18 @@ except ImportError:
                     setattr(dst, name, getattr(src, name))
 
         import types
-
         QtGui = types.ModuleType("PySide.QtGui")
 
         # Combine the attributes of the QtWidgets and QtGui into a new QtGui module.
-        _move_attributes(QtGui, __PySide2_QtWidgets, dir(__PySide2_QtWidgets))
-        _move_attributes(QtGui, __PySide2_QtGui, dir(__PySide2_QtGui))
-    except ImportError:
-        from PySide import QtCore, QtGui
+        _move_attributes(QtGui, __PySide_QtWidgets, dir(__PySide_QtWidgets))
+        _move_attributes(QtGui, __PySide_QtGui, dir(__PySide_QtGui))
+
+
+# Handle QRegExp / QRegularExpression
+if hasattr(QtCore, "QRegularExpression"):
+    qt_re_module = QtCore.QRegularExpression
+    qt_re_module_is_regular_expression = True
+else:
+    # NOTE remove once Qt4 support is removed
+    qt_re_module = QtCore.QRegExp
+    qt_re_module_is_regular_expression = False

--- a/python/app/qt_importer.py
+++ b/python/app/qt_importer.py
@@ -25,6 +25,7 @@ except ImportError:
         from PySide2 import QtCore
         import PySide2.QtGui as __PySide_QtGui
         import PySide2.QtWidgets as __PySide_QtWidgets
+
         imported_qt = True
     except ImportError:
         pass
@@ -35,6 +36,7 @@ except ImportError:
             from PySide6 import QtCore
             import PySide6.QtGui as __PySide_QtGui
             import PySide6.QtWidgets as __PySide_QtWidgets
+
             imported_qt = True
         except ImportError:
             pass

--- a/python/app/qt_importer.py
+++ b/python/app/qt_importer.py
@@ -19,24 +19,27 @@ try:
 except ImportError:
     __PySide_QtGui = None
     __PySide_QtWidgets = None
+    imported_qt = False
     try:
         # Try to import from PySide2
         from PySide2 import QtCore
         import PySide2.QtGui as __PySide_QtGui
         import PySide2.QtWidgets as __PySide_QtWidgets
+        imported_qt = True
     except ImportError:
         pass
 
-    if __PySide_QtGui is None or __PySide_QtWidgets is None:
+    if not imported_qt:
         # Try PySide6
         try:
             from PySide6 import QtCore
             import PySide6.QtGui as __PySide_QtGui
             import PySide6.QtWidgets as __PySide_QtWidgets
+            imported_qt = True
         except ImportError:
             pass
 
-    if __PySide_QtGui is None or __PySide_QtWidgets is None:
+    if not imported_qt:
         # Try PySide
         from PySide import QtCore, QtGui
     else:
@@ -54,6 +57,7 @@ except ImportError:
                     setattr(dst, name, getattr(src, name))
 
         import types
+
         QtGui = types.ModuleType("PySide.QtGui")
 
         # Combine the attributes of the QtWidgets and QtGui into a new QtGui module.


### PR DESCRIPTION
Until Qt4/PySide is deprecated, support both Qt6 and Qt4 at the same time

* QRegExp is removed starting in Qt6 and cannot be easily patched like other modules
* Add support to use QRegularExpression instead of QRegExp when the qt binding is PySide6