### PR TITLE
Rename the PTR Python Console to Python Console

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,7 +53,7 @@ class PythonConsoleApp(sgtk.platform.Application):
         # also register a menu entry on the shotgun menu so that users
         # can launch the panel
         self.engine.register_command(
-            "PTR Python Console...",
+            "Python Console...",
             self.create_panel,
             {"type": "context_menu", "short_name": "python_console"},
         )
@@ -91,7 +91,7 @@ class PythonConsoleApp(sgtk.platform.Application):
         try:
             widget = self.engine.show_panel(
                 self._unique_panel_id,
-                "PTR Python Console",
+                "Python Console",
                 self,
                 app_payload.shotgun_console.ShotgunPythonConsoleWidget,
                 engine=self.engine,

--- a/info.yml
+++ b/info.yml
@@ -26,7 +26,7 @@ supported_engines:
 requires_shotgun_fields:
 
 # More verbose description of this item
-display_name: "PTR Python Console"
+display_name: "Python Console"
 description: "A Python console for Flow Production Tracking"
 
 # Required minimum versions for this item to run

--- a/python/app/shotgun_console.py
+++ b/python/app/shotgun_console.py
@@ -55,7 +55,7 @@ class ShotgunPythonConsoleWidget(PythonConsoleWidget):
 
         # add a welcome message to the output widget
         welcome_message = (
-            "Welcome to the PTR Python Console!\n\n"
+            "Welcome to the Flow Production Tracking Python Console!\n\n"
             "Python %s\n\n"
             "- A tk API handle is available via the 'tk' variable\n"
             "- A PTR API handle is available via the 'shotgun' variable\n"


### PR DESCRIPTION
Rename the PTR Python Console to Python Console

Before:
<img width="718" alt="before_renaming_python_console" src="https://github.com/shotgunsoftware/tk-multi-pythonconsole/assets/117092886/d675eee5-99ab-4729-9043-1d854a0b52da">

After:
<img width="697" alt="after_renaming_python_console" src="https://github.com/shotgunsoftware/tk-multi-pythonconsole/assets/117092886/b207d4a0-0502-4262-a306-fddaa16b7459">

Before/After expanded Python Console Widget
<img width="825" alt="before_after_expanded_python_console_widget" src="https://github.com/shotgunsoftware/tk-multi-pythonconsole/assets/117092886/21f16318-5189-4a31-b463-9aafa45a473a">
