### PR TITLE
SG-38078 workaround with new function to import packages with pyside6 conflicts

### DIFF
--- a/python/app/shotgun_console.py
+++ b/python/app/shotgun_console.py
@@ -9,8 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sys
-import json
-import subprocess
 
 import sgtk
 from sgtk.errors import TankError


### PR DESCRIPTION
### **Description**

Add support for safe_import from tk-framework-shotgunutils

This update introduces the **safe_import** utility into the Python Console's default environment, if available. This function allows safely importing and interacting with isolated modules in a subprocess, preventing conflicts (e.g., with PySide or native dependencies).

If the required version of **tk-framework-shotgunutils** is not available or lacks safe_import, a warning is logged and the variable is set to None.

related with https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/165

### **Tests**

![image](https://github.com/user-attachments/assets/0cb2f332-0b4f-466e-973e-c5321e825ef2)
![image](https://github.com/user-attachments/assets/31342c8e-5f9f-4ef9-b84d-b97fe419585b)